### PR TITLE
DEVOPS-4175: Add requisite libs to linux container image

### DIFF
--- a/AgentImages/Azure-Pipelines.yml
+++ b/AgentImages/Azure-Pipelines.yml
@@ -31,16 +31,19 @@ stages:
     - task: Docker@2
       displayName: Build and push an image to container registry
       inputs:
-        command: buildAndPush
-        repository: $(imageRepository)/linux
-        dockerfile: $(linuxDockerfilePath)
-        containerRegistry: $(dockerRegistryServiceConnection)
-        tags: ubuntu-16.04
+        containerRegistry: '$(dockerRegistryServiceConnection)'
+        repository: '$(imageRepository)/linux'
+        command: 'buildAndPush'
+        Dockerfile: '**/Dockerfile'
+        tags: |
+          ubuntu-16.04
+          latest
+          $(Build.BuildNumber)
   - job: Build_Windows
     displayName: Build Windows Image(s)
     condition: eq(variables['buildWindowsImage'],'true')
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'windows-latest'
     steps:
     - task: Docker@2
       displayName: Build and push an image to container registry

--- a/AgentImages/Basic/Ubuntu/Dockerfile
+++ b/AgentImages/Basic/Ubuntu/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update \
         netcat \
         wget \ 
         apt-transport-https \ 
-        gnupg
+        gnupg \ 
+        openssh-client
 
 # this is needed because otherwise it can't find dotnetcore 3.1 later on.  taken from:
 #  https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1604#troubleshoot-the-package-manager

--- a/AgentImages/Basic/Ubuntu/Dockerfile
+++ b/AgentImages/Basic/Ubuntu/Dockerfile
@@ -16,18 +16,34 @@ RUN apt-get update \
         libicu55 \
         libunwind8 \
         netcat \
-        wget
+        wget \ 
+        apt-transport-https \ 
+        gnupg
+
+# this is needed because otherwise it can't find dotnetcore 3.1 later on.  taken from:
+#  https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1604#troubleshoot-the-package-manager
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o microsoft.asc.gpg
+RUN mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
+RUN wget -q https://packages.microsoft.com/config/ubuntu/16.04/prod.list
+RUN mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
+RUN chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
+RUN chown root:root /etc/apt/sources.list.d/microsoft-prod.list
+
+# as per https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1604#install-the-net-core-runtime,
+#  after installing apt-transport-https we need to run update again before installing dotnetcore runtime.....i don't really know why
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends dotnet-sdk-3.1
 
 # Install AZ CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 RUN echo "AZURE_EXTENSION_DIR=/usr/local/lib/azureExtensionDir" | tee -a /etc/environment \
     && mkdir -p /usr/local/lib/azureExtensionDir
 
-# Install powershell core
-RUN wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb \
-        && dpkg -i packages-microsoft-prod.deb \
-        && apt-get update \
-        && apt-get install -y powershell
+# Install powershell core, and azure module
+RUN apt-get install -y powershell
+RUN /usr/bin/pwsh -Command "Install-Module PowerShellGet -Force"
+RUN /usr/bin/pwsh -Command "Install-Module -Name Az -AllowClobber -Force" # -Scope CurrentUser
+# RUN /usr/bin/pwsh -Command "Install-Module -Name Az.Accounts -AllowClobber -Force" # -Scope CurrentUser
 
 WORKDIR /azp
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Differences in this Fork
+
+So far, the only real difference is the addition of the dotnet core 3.1 SDK to the linux agent dockerfile.
+
 # Ephemeral Pipelines Agents
 
 When you want to deploy to Azure Resources that aren't exposed on the internet, and only accessible via a [private network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview) you are excluded from using [Microsoft-hosted agents](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops), and you need to maintain your pool of [self-hosted agents](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/agents?view=azure-devops#install).


### PR DESCRIPTION
Not sure if we want to pull this in, since I don't know if we want the master branch of the agent to have these (optional) packages.

- dotnet core 3.1
- scp